### PR TITLE
[COMMSVC-128] 인덱스 생성 시 사용하는 배열 비교 함수 수정

### DIFF
--- a/lib/index/helper.js
+++ b/lib/index/helper.js
@@ -31,6 +31,6 @@ module.exports = {
       return a === b;
     }
 
-    return a.length && b.length && a.every((e, i) => e === b[i]);
+    return a.length === b.length && a.every((e, i) => e === b[i]);
   },
 };


### PR DESCRIPTION
`knex-automigrate` 모듈에서 새로 생성할 인덱스를 식별할 때 기존 인덱스와 db 스키마에 명시된 인덱스를 비교하는데, 기존 인덱스와 신규로 생성할 인덱스를 동일한 것으로 판단하여 신규 인덱스를 생성하지 않는 문제가 있었습니다.

두 인덱스가 동일한지 비교할 때 `isArrayEqual` 함수를 사용하는데, 길이가 다른 두 배열을 같은 배열로 판단하는 경우가 있어 이를 수정했습니다.
- 수정 전: 기존 인덱스([ 'ref_id'])와 새로 생성할 인덱스([ 'ref_id', 'category', 'reserved_1', 'created_at' ])를 동일한 것으로 판단함
- 수정 후: 기존 인덱스([ 'ref_id'])와 새로 생성할 인덱스([ 'ref_id', 'category', 'reserved_1', 'created_at' ])를 다른 것으로 판단함