### PR TITLE
[COMMSVC-273] View Table DDL 추가 (createView, createViewOrReplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ exports.auto = function(migrator, knex) {
     });
   ];
 });
+
+// view_users.js
+exports.auto = function(migrator, knex) {
+  return [
+    migrator('user_information', (view) => {
+      // If view.columns() is missing,
+      // the columns will default to those defined in the 'select()' statement.
+      view.as(knex('users').select('user_id', 'email', 'name'));
+    }),
+  ];
+});
 ```
 
 ```bash
@@ -131,7 +142,8 @@ Migration files are,
 ```
 App
 　├─ migrations
-　│　　└─ table_users.js
+　│　　├─ table_users.js
+　│　　└─ view_users.js
 　└─ knexfile.js
 ```
 

--- a/lib/automigrate.js
+++ b/lib/automigrate.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 const helper = require('./index/helper');
 
 module.exports = function Automigrate(opts) {
-  return new Promise(((resolve, reject) => {
+  // eslint-disable-next-line no-async-promise-executor
+  return new Promise(async (resolve, reject) => {
     opts = opts || {};
 
     const knex = require('knex')(opts.config); // eslint-disable-line global-require
@@ -35,7 +36,7 @@ module.exports = function Automigrate(opts) {
       });
     };
 
-    const migrator = async function migrator(tableName, fn, initRows) {
+    const migratorTable = async function migrator(tableName, fn, initRows) {
       const exists = await knex.schema.hasTable(tableName);
 
       if (!exists) {
@@ -228,22 +229,134 @@ module.exports = function Automigrate(opts) {
       return tableName;
     };
 
-    const promises = [];
+    const migratorView = async function migrator(viewName, fn) {
+      const tableInfo = (await knex('INFORMATION_SCHEMA.TABLES').select('TABLE_TYPE').where({
+        TABLE_NAME: viewName,
+      }))[0];
+
+      const exists = tableInfo && tableInfo.TABLE_TYPE === 'VIEW';
+
+      if (!exists) {
+        await knex.schema.createView(viewName, (view) => {
+          fn(view);
+        });
+      } else {
+        const existColumns = await knex.from(viewName).columnInfo();
+        const schemaColumns = {};
+
+        await knex.schema.alterView(viewName, (view) => {
+          let prevColumnName;
+          let columnName;
+          const proxy = tabler();
+          fn(proxy);
+
+          const column = function column(t, e, depth) {
+            if (!e || !e[0]) return null;
+
+            const method = e[1];
+
+            if (depth === 0) {
+              columnName = e[2][0];
+              schemaColumns[columnName] = true;
+            }
+
+            if (method === 'columns' || method === 'as') {
+              return t;
+            }
+
+            if ((method === 'increments' || method === 'bigIncrements')) {
+              return t;
+            }
+
+            e[0].__appended__.forEach((ee) => { // eslint-disable-line no-underscore-dangle
+              t = column(t, ee, depth + 1);
+            });
+
+            if (depth === 0) {
+              if (['foreign'].indexOf(method) !== -1) {
+                /* eslint-disable no-empty */
+              } else if (['index', 'unique'].indexOf(method) === -1) {
+                if (existColumns[columnName]) {
+                  t.alter();
+                } else if (prevColumnName) {
+                  t = t.after(prevColumnName);
+                } else {
+                  t = t.first();
+                }
+              }
+
+              prevColumnName = columnName;
+            }
+
+            return t;
+          };
+
+          proxy.__appended__.forEach((e) => { // eslint-disable-line no-underscore-dangle
+            column(view, e, 0);
+          });
+
+          // Drop unused columns.
+          const dropColumns = [];
+
+          Object.keys(existColumns).forEach((e) => {
+            if (!schemaColumns[e]) {
+              dropColumns.push(e);
+            }
+          });
+
+          if (dropColumns.length > 0) {
+            if (opts.config.safe) {
+              if (opts.verbose !== false) {
+                /* eslint-disable no-console */
+                console.warn(`* [Skip Drop Column${dropColumns.length > 1 ? 's' : ''}] \`${viewName}\``);
+                console.warn(`  ${'-'.repeat(20)}`);
+                console.warn(`  ALTER VIEW \`${viewName}\` \n    ${dropColumns.map((c) => `DROP COLUMN \`${c}\``).join(',\n    ')};`);
+                console.warn(`  ${'-'.repeat(20)}`);
+              }
+            } else {
+              view.dropColumns(dropColumns);
+            }
+          }
+        });
+      }
+
+      return viewName;
+    };
+
+    const promises = {
+      tables: [],
+      views: [],
+    };
     opts.path = opts.cwd || process.cwd();
 
-    const dummyMigrator = (a, b, c) => ({
+    const dummyMigrator = (fn) => (a, b, c) => fn(a, b, c);
+
+    const tableMigrator = (a, b, c) => ({
       call: async () => {
-        const res = await migrator(a, b, c);
+        const res = await migratorTable(a, b, c);
+        return res;
+      },
+    });
+
+    const viewMigrator = (a, b) => ({
+      call: async () => {
+        const res = await migratorView(a, b);
         return res;
       },
     });
 
     fs.readdirSync(opts.path).forEach((name) => {
-      if (name.slice(0, 6) !== 'table_') return;
+      if (name.slice(0, 6) !== 'table_' && name.slice(0, 5) !== 'view_') return;
+
+      const isTable = name.slice(0, 6) === 'table_';
 
       // eslint-disable-next-line global-require, import/no-dynamic-require
-      require(`${opts.path}/${name}`).auto(dummyMigrator, knex).forEach((e) => {
-        promises.push([name, e]);
+      require(`${opts.path}/${name}`).auto(dummyMigrator(isTable ? tableMigrator : viewMigrator), knex).forEach((e) => {
+        if (isTable) {
+          promises.tables.push([name, e]);
+        } else {
+          promises.views.push([name, e]);
+        }
       });
     });
 
@@ -251,31 +364,38 @@ module.exports = function Automigrate(opts) {
       promises.push(...opts.tables(dummyMigrator, knex).map((table) => ['table_on_demand', table]));
     }
 
-    const execute = function execute(i) {
-      promises[i][1].call().then((res) => {
+    const convert = (type) => type.charAt(0).toUpperCase() + type.slice(1, -1);
+
+    const execute = async function execute(i, type) {
+      try {
+        const res = await promises[type][i][1].call();
+
         if (opts.verbose !== false) {
-          console.info(`* Table \`${res}\` has been migrated.`); // eslint-disable-line no-console
+          console.info(`* ${convert(type)} \`${res}\` has been migrated.`); // eslint-disable-line no-console
         }
 
-        if (i < promises.length - 1) {
-          execute(i + 1);
-        } else {
-          resolve();
+        if (i < promises[type].length - 1) {
+          await execute(i + 1, type);
         }
-      }).catch((err) => {
+      } catch (err) {
         if (opts.verbose !== false) {
-          console.error(`* Table \`${promises[i][0]}\` migration failed.`); // eslint-disable-line no-console
+          console.error(`* ${convert(type)} \`${promises[type][i][0]}\` migration failed.`); // eslint-disable-line no-console
         }
 
         reject(err);
-      });
+      }
     };
 
-    if (promises.length > 0) {
-      execute(0);
-    } else {
-      console.info('* No schema exist.'); // eslint-disable-line no-console
-      resolve();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const type of Object.keys(promises)) {
+      if (promises[type].length > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        await execute(0, type);
+      } else {
+        console.info(`* No ${convert(type)} schema exist.`); // eslint-disable-line no-console
+      }
     }
-  }));
+
+    resolve();
+  });
 };

--- a/lib/automigrate.js
+++ b/lib/automigrate.js
@@ -243,12 +243,13 @@ module.exports = function Automigrate(opts) {
       fn(proxy);
 
       // eslint-disable-next-line no-underscore-dangle
-      const { schemaColumns, schemaAs } = proxy.__appended__.reduce((acc, cur) => {
+      const { schemaColumns } = proxy.__appended__.reduce((acc, cur) => {
         if (cur[1] === 'columns') {
           if (acc.schemaColumns) throw new Error('Only one "columns" can be used.');
 
           acc.schemaColumns = cur[2][0];
         }
+
         if (cur[1] === 'as') {
           if (acc.schemaAs) throw new Error('Only one "as" can be used.');
 
@@ -268,25 +269,20 @@ module.exports = function Automigrate(opts) {
       } else {
         const existColumns = await knex.from(viewName).columnInfo();
         const dropColumns = Object.keys(existColumns)
-          .filter((existColumn) => !schemaColumns.includes(existColumn));
+          .filter((existColumn) => schemaColumns && !schemaColumns.includes(existColumn));
+
+        if (dropColumns.length > 0) {
+          if (opts.verbose !== false) {
+            /* eslint-disable no-console */
+            console.warn(`* [Drop Column${dropColumns.length > 1 ? 's' : ''}] \`${viewName}\``);
+            console.warn(`  ${'-'.repeat(20)}`);
+            console.warn(`  ALTER VIEW \`${viewName}\` \n    ${dropColumns.map((c) => `DROP COLUMN \`${c}\``).join(',\n    ')};`);
+            console.warn(`  ${'-'.repeat(20)}`);
+          }
+        }
 
         await knex.schema.createViewOrReplace(viewName, (view) => {
-          view.columns(schemaColumns.concat(dropColumns));
-          view.as(schemaAs.select(dropColumns.map((dropColumn) => knex.raw(`null as '${dropColumn}'`))));
-
-          if (dropColumns.length > 0) {
-            if (opts.config.safe) {
-              if (opts.verbose !== false) {
-                /* eslint-disable no-console */
-                console.warn(`* [Skip Drop Column${dropColumns.length > 1 ? 's' : ''}] \`${viewName}\``);
-                console.warn(`  ${'-'.repeat(20)}`);
-                console.warn(`  (${dropColumns.join(', ')}) column${dropColumns.length > 1 ? 's' : ''} will not be removed but will appear with NULL values. `);
-                console.warn(`  ${'-'.repeat(20)}`);
-              }
-            } else {
-              //
-            }
-          }
+          fn(view);
         });
       }
 
@@ -297,6 +293,7 @@ module.exports = function Automigrate(opts) {
       tables: [],
       views: [],
     };
+
     opts.path = opts.cwd || process.cwd();
 
     const dummyMigrator = (fn) => (a, b, c) => fn(a, b, c);

--- a/lib/automigrate.js
+++ b/lib/automigrate.js
@@ -36,7 +36,7 @@ module.exports = function Automigrate(opts) {
       });
     };
 
-    const migratorTable = async function migrator(tableName, fn, initRows) {
+    const migrateTable = async function migrator(tableName, fn, initRows) {
       const exists = await knex.schema.hasTable(tableName);
 
       if (!exists) {
@@ -229,12 +229,37 @@ module.exports = function Automigrate(opts) {
       return tableName;
     };
 
-    const migratorView = async function migrator(viewName, fn) {
-      const tableInfo = (await knex('INFORMATION_SCHEMA.TABLES').select('TABLE_TYPE').where({
+    const migrateView = async function migrator(viewName, fn) {
+      const exists = (await knex('INFORMATION_SCHEMA.TABLES').select('TABLE_SCHEMA', 'TABLE_TYPE').where({
+        TABLE_SCHEMA: opts.config.connection.database,
         TABLE_NAME: viewName,
       }))[0];
 
-      const exists = tableInfo && tableInfo.TABLE_TYPE === 'VIEW';
+      if (exists && exists.TABLE_TYPE === 'BASE TABLE') {
+        throw new Error(`* ${viewName} must be a view, but a table already exists with this name.`);
+      }
+
+      const proxy = tabler();
+      fn(proxy);
+
+      // eslint-disable-next-line no-underscore-dangle
+      const { schemaColumns, schemaAs } = proxy.__appended__.reduce((acc, cur) => {
+        if (cur[1] === 'columns') {
+          if (acc.schemaColumns) throw new Error('Only one "columns" can be used.');
+
+          acc.schemaColumns = cur[2][0];
+        }
+        if (cur[1] === 'as') {
+          if (acc.schemaAs) throw new Error('Only one "as" can be used.');
+
+          acc.schemaAs = cur[2][0];
+        }
+
+        return acc;
+      }, {
+        schemaColumns: null,
+        schemaAs: null,
+      });
 
       if (!exists) {
         await knex.schema.createView(viewName, (view) => {
@@ -242,67 +267,12 @@ module.exports = function Automigrate(opts) {
         });
       } else {
         const existColumns = await knex.from(viewName).columnInfo();
-        const schemaColumns = {};
+        const dropColumns = Object.keys(existColumns)
+          .filter((existColumn) => !schemaColumns.includes(existColumn));
 
-        await knex.schema.alterView(viewName, (view) => {
-          let prevColumnName;
-          let columnName;
-          const proxy = tabler();
-          fn(proxy);
-
-          const column = function column(t, e, depth) {
-            if (!e || !e[0]) return null;
-
-            const method = e[1];
-
-            if (depth === 0) {
-              columnName = e[2][0];
-              schemaColumns[columnName] = true;
-            }
-
-            if (method === 'columns' || method === 'as') {
-              return t;
-            }
-
-            if ((method === 'increments' || method === 'bigIncrements')) {
-              return t;
-            }
-
-            e[0].__appended__.forEach((ee) => { // eslint-disable-line no-underscore-dangle
-              t = column(t, ee, depth + 1);
-            });
-
-            if (depth === 0) {
-              if (['foreign'].indexOf(method) !== -1) {
-                /* eslint-disable no-empty */
-              } else if (['index', 'unique'].indexOf(method) === -1) {
-                if (existColumns[columnName]) {
-                  t.alter();
-                } else if (prevColumnName) {
-                  t = t.after(prevColumnName);
-                } else {
-                  t = t.first();
-                }
-              }
-
-              prevColumnName = columnName;
-            }
-
-            return t;
-          };
-
-          proxy.__appended__.forEach((e) => { // eslint-disable-line no-underscore-dangle
-            column(view, e, 0);
-          });
-
-          // Drop unused columns.
-          const dropColumns = [];
-
-          Object.keys(existColumns).forEach((e) => {
-            if (!schemaColumns[e]) {
-              dropColumns.push(e);
-            }
-          });
+        await knex.schema.createViewOrReplace(viewName, (view) => {
+          view.columns(schemaColumns.concat(dropColumns));
+          view.as(schemaAs.select(dropColumns.map((dropColumn) => knex.raw(`null as '${dropColumn}'`))));
 
           if (dropColumns.length > 0) {
             if (opts.config.safe) {
@@ -310,11 +280,11 @@ module.exports = function Automigrate(opts) {
                 /* eslint-disable no-console */
                 console.warn(`* [Skip Drop Column${dropColumns.length > 1 ? 's' : ''}] \`${viewName}\``);
                 console.warn(`  ${'-'.repeat(20)}`);
-                console.warn(`  ALTER VIEW \`${viewName}\` \n    ${dropColumns.map((c) => `DROP COLUMN \`${c}\``).join(',\n    ')};`);
+                console.warn(`  (${dropColumns.join(', ')}) column${dropColumns.length > 1 ? 's' : ''} will not be removed but will appear with NULL values. `);
                 console.warn(`  ${'-'.repeat(20)}`);
               }
             } else {
-              view.dropColumns(dropColumns);
+              //
             }
           }
         });
@@ -333,14 +303,14 @@ module.exports = function Automigrate(opts) {
 
     const tableMigrator = (a, b, c) => ({
       call: async () => {
-        const res = await migratorTable(a, b, c);
+        const res = await migrateTable(a, b, c);
         return res;
       },
     });
 
     const viewMigrator = (a, b) => ({
       call: async () => {
-        const res = await migratorView(a, b);
+        const res = await migrateView(a, b);
         return res;
       },
     });

--- a/test/migration/view_00_common.js
+++ b/test/migration/view_00_common.js
@@ -1,8 +1,26 @@
 /* eslint-disable newline-per-chained-call, global-require, no-undef */
 
 exports.auto = (migrator, knex) => [
-  migrator('VIEW_KEYVALS_ID', (view) => {
-    view.columns(['VAL']);
-    view.as(knex('KEYVALS_ID').select('VAL'));
+  migrator('KEYVALS_ID2', (view) => {
+    view.columns(['val', 'created_at', 'expiry_at']);
+    view.as(knex('KEYVALS_ID').select('VAL', 'CREATED_AT', 'EXPIRY_AT'));
+  }),
+  migrator('student_information', (view) => {
+    view.as(
+      knex('STUDENTS')
+        .select('STUDENT_ID', 'NAME', 'HOME_PHONE.PHONE as HOME_PHONE_NUMBER', 'MOBILE_PHONE.PHONE as MOBILE_PHONE_NUMBER')
+        .join(
+          'PHONES as HOME_PHONE',
+          'STUDENTS.HOME_PHONE_ID',
+          '=',
+          'HOME_PHONE.PHONE_ID',
+        )
+        .join(
+          'PHONES as MOBILE_PHONE',
+          'STUDENTS.MOBILE_PHONE_ID',
+          '=',
+          'MOBILE_PHONE.PHONE_ID',
+        ),
+    );
   }),
 ];

--- a/test/migration/view_00_common.js
+++ b/test/migration/view_00_common.js
@@ -1,0 +1,8 @@
+/* eslint-disable newline-per-chained-call, global-require, no-undef */
+
+exports.auto = (migrator, knex) => [
+  migrator('VIEW_KEYVALS_ID', (view) => {
+    view.columns(['VAL']);
+    view.as(knex('KEYVALS_ID').select('VAL'));
+  }),
+];

--- a/test/migration/view_00_common.js
+++ b/test/migration/view_00_common.js
@@ -2,25 +2,8 @@
 
 exports.auto = (migrator, knex) => [
   migrator('KEYVALS_ID2', (view) => {
-    view.columns(['val', 'created_at', 'expiry_at']);
+    // If view.columns() is missing,
+    // the columns will default to those defined in the 'select()' statement.
     view.as(knex('KEYVALS_ID').select('VAL', 'CREATED_AT', 'EXPIRY_AT'));
-  }),
-  migrator('student_information', (view) => {
-    view.as(
-      knex('STUDENTS')
-        .select('STUDENT_ID', 'NAME', 'HOME_PHONE.PHONE as HOME_PHONE_NUMBER', 'MOBILE_PHONE.PHONE as MOBILE_PHONE_NUMBER')
-        .join(
-          'PHONES as HOME_PHONE',
-          'STUDENTS.HOME_PHONE_ID',
-          '=',
-          'HOME_PHONE.PHONE_ID',
-        )
-        .join(
-          'PHONES as MOBILE_PHONE',
-          'STUDENTS.MOBILE_PHONE_ID',
-          '=',
-          'MOBILE_PHONE.PHONE_ID',
-        ),
-    );
   }),
 ];

--- a/test/migration/view_01_relation.js
+++ b/test/migration/view_01_relation.js
@@ -1,0 +1,30 @@
+/* eslint-disable newline-per-chained-call, global-require, no-undef */
+
+exports.auto = (migrator, knex) => [
+  migrator('STUDENT_INFORMATION', (view) => {
+    view.columns(['student_id', 'name', 'home_phone_number', 'mobile_phone_number', 'email']);
+    view.as(
+      knex('STUDENTS AS S')
+        .select('S.STUDENT_ID', 'NAME', 'HOME_PHONE.PHONE', 'MOBILE_PHONE.PHONE', 'SD.EMAIL')
+        .leftJoin(
+          'PHONES AS HOME_PHONE',
+          'S.HOME_PHONE_ID',
+          '=',
+          'HOME_PHONE.PHONE_ID',
+        )
+        .leftJoin(
+          'PHONES AS MOBILE_PHONE',
+          'S.MOBILE_PHONE_ID',
+          '=',
+          'MOBILE_PHONE.PHONE_ID',
+        )
+        .leftJoin(
+          'STUDENTS_DETAIL AS SD',
+          'S.STUDENT_ID',
+          '=',
+          'SD.STUDENT_ID',
+        )
+      ,
+    );
+  }),
+];


### PR DESCRIPTION
View Table을 Migration 할수 있는 기능을 추가했습니다.

#### Description

기존 기능인 Table Migration에는 영향이 없도록 작업하였으나 놓친 부분이 있을수 있으니 확인이 필요합니다.

1. Table Migration 진행후 View Migration을 진행합니다.
2. View의 파일명은 `view_`로 시작되어야합니다.
3. View Migration시에는 컬럼을 삭제할경우 그대로 반영됩니다. (Table Migration시에는 컬럼이 삭제 되더라도 실제 Migration시에는 컬럼을 삭제하지 않음)

#
파일명은 `view_`로 시작되어야하며, view 파일내에서 사용할수 있는 함수는 [knex 공식 문서](https://knexjs.org/guide/schema-builder.html#view)에서 확인 가능합니다.
[`checkOption`, `localCheckOption`, `cascadedCheckOption`도 가능](https://dev.mysql.com/doc/refman/8.4/en/view-check-option.html)하나 따로 예외처리는 하지 않았습니다.
- `alterView`는 [knex에서 mysql은 지원하지 않아서](https://knexjs.org/guide/schema-builder.html#alterview) `createViewOrReplace`를 사용하였습니다.
- view.columns()는 생략 가능하며, 생략한 경우 view.as()내에서 select()한 컬럼으로 자동 구성됩니다.

#### Safe Mode
- View는 데이터에 영향이 없다고 판단하여 Safe Mode 제한을 두지 않고, 파일에 정의된 내용대로 수정되게 하였습니다.
- (코드상에서 수정이 안될경우에는 에러가 발생할수 있습니다.)

Table은 migration 파일에서 컬럼을 삭제해도 실제 삭제까진 이루어지지 않음
- (대신 name 컬럼을 파일에서 삭제해도 실제 DB에는 name 컬럼이 남아있는 상태)

- View는 name, password, phone, email 컬럼으로 생성해놓은 상태에서
- password 컬럼을 migration 파일에서 삭제할경우
- name, phone, email로만 View가 구성됨