### PR TITLE
Add CLI tests in a dedicated test file

### DIFF
--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,81 @@
+const path = require('path');
+const { spawnSync } = require('child_process');
+const knex = require('knex');
+const pkg = require('../package.json');
+const config = require('./migration/knex.config');
+
+const CLI = path.join(__dirname, '..', 'bin', 'cli.js');
+const MIGRATION_CWD = path.join(__dirname, 'migration');
+const KNEXFILE = path.join(MIGRATION_CWD, 'knex.config.js');
+
+const run = (args, opts = {}) => spawnSync(process.execPath, [CLI, ...args], {
+  encoding: 'utf8',
+  timeout: 30000,
+  ...opts,
+});
+
+// ---------------------------------------------------------------------------
+// Unit-style tests — no database required
+// ---------------------------------------------------------------------------
+
+describe('CLI — no database required', () => {
+  it('prints the package version and exits 0', () => {
+    const result = run(['--version']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(pkg.version);
+  });
+
+  it('exits 1 with an error message when no knexfile is found', () => {
+    const result = run(['migrate:auto', '--cwd', '/tmp']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('No knexfile found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — require a running MySQL instance
+// ---------------------------------------------------------------------------
+
+describe('CLI — migrate:auto', () => {
+  const sharedKnex = knex(config);
+
+  // Tables listed in FK-safe drop order (STUDENTS before PHONES).
+  const fileViews = ['STUDENT_INFORMATION', 'KEYVALS_ID2'];
+  const fileTables = [
+    'STUDENTS_CLASSES_DETAIL',
+    'STUDENTS_CLASSES',
+    'STUDENTS_DETAIL',
+    'CLASSES_DETAIL',
+    'CLASSES',
+    'STUDENTS',
+    'PHONES',
+    'KEYVALS_ID',
+  ];
+
+  const dropAll = async () => {
+    await Promise.all(fileViews.map((v) => sharedKnex.schema.dropViewIfExists(v)));
+    await fileTables.reduce(
+      (chain, t) => chain.then(() => sharedKnex.schema.dropTableIfExists(t)),
+      Promise.resolve(),
+    );
+  };
+
+  beforeAll(dropAll);
+
+  afterAll(async () => {
+    await dropAll();
+    await sharedKnex.destroy();
+  });
+
+  it('creates all tables and views on first run and exits 0', () => {
+    const result = run(['migrate:auto', '--knexfile', KNEXFILE, '--cwd', MIGRATION_CWD]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Migration successfully done');
+  });
+
+  it('is idempotent — exits 0 on a second run against already-migrated tables', () => {
+    const result = run(['migrate:auto', '--knexfile', KNEXFILE, '--cwd', MIGRATION_CWD]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Migration successfully done');
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -832,5 +832,4 @@ describe('knex-automigrate', () => {
       );
     });
   });
-
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -726,7 +726,7 @@ describe('knex-automigrate', () => {
 
   describe('file-based migration', () => {
     // All tables/views produced by test/migration/table_*.js and view_*.js files.
-    // Drop order respects FK dependencies (child tables before parents).
+    // Tables are listed in FK-safe drop order (STUDENTS before PHONES).
     const fileViews = ['STUDENT_INFORMATION', 'KEYVALS_ID2'];
     const fileTables = [
       'STUDENTS_CLASSES_DETAIL',
@@ -739,11 +739,14 @@ describe('knex-automigrate', () => {
       'KEYVALS_ID',
     ];
 
+    // Views are dropped in parallel (no FK deps).
+    // Tables are dropped sequentially to respect FK order (STUDENTS before PHONES).
     const dropAll = async () => {
-      await getKnex().raw('SET foreign_key_checks = 0');
       await Promise.all(fileViews.map((v) => getKnex().schema.dropViewIfExists(v)));
-      await Promise.all(fileTables.map((t) => getKnex().schema.dropTableIfExists(t)));
-      await getKnex().raw('SET foreign_key_checks = 1');
+      await fileTables.reduce(
+        (chain, t) => chain.then(() => getKnex().schema.dropTableIfExists(t)),
+        Promise.resolve(),
+      );
     };
 
     beforeAll(dropAll);
@@ -829,4 +832,5 @@ describe('knex-automigrate', () => {
       );
     });
   });
+
 });


### PR DESCRIPTION
## Summary

- Add `test/cli.test.js` with two categories of tests:
  - **Unit-style** (no DB): `--version` prints the correct version and exits 0; `migrate:auto` without a knexfile exits 1 with an error message
  - **Integration** (real MySQL): `migrate:auto` creates all tables/views and exits 0; running again is idempotent
- Fix a deadlock in the `file-based migration` teardown in `test/index.test.js`: replaced `SET foreign_key_checks = 0` + `Promise.all` (which spread drops across different connections, making the session variable ineffective) with sequential drops in FK-safe order via `reduce`

## Test plan

- [ ] `npm test` — all 128 tests pass, no deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)