### PR TITLE
Fix bugs in helper.js and migrateView

### DIFF
--- a/lib/automigrate.js
+++ b/lib/automigrate.js
@@ -291,34 +291,33 @@ module.exports = function Automigrate(opts) {
         throw new Error(`* ${viewName} must be a view, but a table already exists with this name.`);
       }
 
-      const proxy = tabler();
-
-      // eslint-disable-next-line no-underscore-dangle
-      const { schemaColumns } = proxy.__appended__.reduce((acc, cur) => {
-        if (cur[1] === 'columns') {
-          if (acc.schemaColumns) throw new Error('Only one "columns" can be used.');
-
-          acc.schemaColumns = cur[2][0];
-        }
-
-        if (cur[1] === 'as') {
-          if (acc.schemaAs) throw new Error('Only one "as" can be used.');
-
-          acc.schemaAs = cur[2][0];
-        }
-
-        return acc;
-      }, {
-        schemaColumns: null,
-        schemaAs: null,
-      });
-
       if (!exists) {
         await knex.schema.createView(viewName, (view) => {
           fn(view);
         });
       } else {
+        const proxy = tabler();
         fn(proxy);
+
+        // eslint-disable-next-line no-underscore-dangle
+        const { schemaColumns } = proxy.__appended__.reduce((acc, cur) => {
+          if (cur[1] === 'columns') {
+            if (acc.schemaColumns) throw new Error('Only one "columns" can be used.');
+
+            acc.schemaColumns = cur[2][0];
+          }
+
+          if (cur[1] === 'as') {
+            if (acc.schemaAs) throw new Error('Only one "as" can be used.');
+
+            acc.schemaAs = cur[2][0];
+          }
+
+          return acc;
+        }, {
+          schemaColumns: null,
+          schemaAs: null,
+        });
 
         const existColumns = await knex.from(viewName).columnInfo();
         const dropColumns = Object.keys(existColumns)

--- a/lib/index/helper.js
+++ b/lib/index/helper.js
@@ -5,7 +5,7 @@ module.exports = {
     const begin = e.indexOf('(');
     const end = e.lastIndexOf(')');
 
-    if (begin === -1 || end === -1) return null;
+    if (begin === -1 || end === -1 || begin >= end) return null;
     return e.slice(begin + 1, end);
   },
   multipleColumns(e) {
@@ -24,13 +24,10 @@ module.exports = {
   firstQuoteValue(e) {
     if (e.indexOf('`') === -1) return null;
     e = e.slice(e.indexOf('`') + 1);
-    return e.slice(0, e.indexOf('`'));
+    const closing = e.indexOf('`');
+    return closing === -1 ? e : e.slice(0, closing);
   },
   isArrayEqual(a, b) {
-    if (typeof (a) === typeof (b) === 'string') {
-      return a === b;
-    }
-
     return a.length === b.length && a.every((e, i) => e === b[i]);
   },
 };

--- a/test/unit/helper.test.js
+++ b/test/unit/helper.test.js
@@ -27,11 +27,8 @@ describe('helper', () => {
       assert.strictEqual(helper.innerBrackets('KEY ()'), '');
     });
 
-    it('documents quirk: closing bracket before opening bracket returns empty string, not null', () => {
-      // ') foo (' → indexOf('(')=7, lastIndexOf(')')=0 → neither is -1 (null check is bypassed)
-      // → slice(begin+1, end) = slice(8, 0) = '' instead of null.
-      // TypeScript refactoring should add a begin > end guard.
-      assert.strictEqual(helper.innerBrackets(') foo ('), '');
+    it('returns null when closing bracket appears before opening bracket', () => {
+      assert.strictEqual(helper.innerBrackets(') foo ('), null);
     });
 
     it('handles UNIQUE KEY line as produced by SHOW CREATE TABLE', () => {
@@ -126,12 +123,8 @@ describe('helper', () => {
       assert.strictEqual(helper.firstQuoteValue('KEY `` ()'), '');
     });
 
-    it('documents bug: only one backtick causes slice(0,-1) to truncate the last character', () => {
-      // If there is no closing backtick, indexOf('`') on the remainder returns -1.
-      // slice(0, -1) then removes the last character of the extracted string.
-      // e.g. 'KEY `idx_name' → remainder = 'idx_name' → slice(0,-1) = 'idx_nam'
-      // TypeScript refactoring must guard against -1 before slicing.
-      assert.strictEqual(helper.firstQuoteValue('KEY `idx_name'), 'idx_nam');
+    it('returns the full value when no closing backtick is present', () => {
+      assert.strictEqual(helper.firstQuoteValue('KEY `idx_name'), 'idx_name');
     });
   });
 
@@ -155,13 +148,6 @@ describe('helper', () => {
     it('returns true for two empty arrays (length equality check: 0 === 0)', () => {
       // a.length === b.length → 0 === 0 → true, and [].every() vacuously returns true.
       assert.ok(helper.isArrayEqual([], []));
-    });
-
-    it('documents that the typeof chain shortcut is dead code', () => {
-      // typeof(a) === typeof(b) evaluates to a boolean.
-      // boolean === 'string' is always false, so the string-equality branch is never reached.
-      const result = typeof ('x') === typeof ('y') === 'string';
-      assert.strictEqual(result, false);
     });
 
     it('returns falsy when array lengths differ (longer second array)', () => {


### PR DESCRIPTION
## Summary

### `lib/index/helper.js`

- **`innerBrackets`**: Added `begin >= end` guard to return `null` when the closing bracket appears before the opening bracket (previously returned `''`)
- **`firstQuoteValue`**: Fixed truncation of the last character when no closing backtick is present — `slice(0, -1)` was silently dropping the final character; now returns the full remainder
- **`isArrayEqual`**: Removed unreachable `typeof` branch — `typeof(a) === typeof(b)` evaluates to a boolean which is never `=== 'string'`, making the entire string-equality shortcut dead code

### `lib/automigrate.js`

- **`migrateView`**: Moved `proxy.__appended__.reduce()` inside the `else` branch, after `fn(proxy)`. Previously the reduce ran on an empty proxy before `fn` was called, so `schemaColumns` was always `null` and the view column drop warning never fired

## Test plan

- [ ] `npm test` — 127 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)